### PR TITLE
fix: with new user creation — 502 error.

### DIFF
--- a/src/routes/panel.js
+++ b/src/routes/panel.js
@@ -713,6 +713,9 @@ router.get('/users/add', requireAuth, async (req, res) => {
         title: 'Новый пользователь',
         page: 'users',
         groups,
+        isEdit: false,
+        user: null,
+        error: null,
     });
 });
 


### PR DESCRIPTION

<img width="1912" height="1242" alt="add_user_bug" src="https://github.com/user-attachments/assets/5eca7fc9-9098-453a-91bb-69ced27b5113" />
Please check the new user creation/addition — it was broken on dashboard and users pages, this is a hotfix.