### PR TITLE
feat: add SSH private key download action for nodes

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1760,6 +1760,11 @@ html {
     cursor: not-allowed;
 }
 
+.action-btn.is-disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
 .action-btn .action-icon {
     font-size: 16px;
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -160,6 +160,8 @@
     "sshKeyGenerating": "Generating and installing key...",
     "sshKeyInstalled": "SSH key generated and installed!",
     "sshKeyError": "Key generation error",
+    "downloadSshKey": "Download SSH Key",
+    "downloadSshKeyMissing": "SSH private key is not configured for this node",
     "maxOnlineUsers": "Online Users Limit",
     "maxOnlineHint": "0 = unlimited. If exceeded, node is hidden from subscription (if enabled).",
     "rankingCoefficient": "Priority (ranking)",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -160,6 +160,8 @@
     "sshKeyGenerating": "Генерация и установка ключа...",
     "sshKeyInstalled": "SSH ключ сгенерирован и установлен!",
     "sshKeyError": "Ошибка генерации ключа",
+    "downloadSshKey": "Скачать SSH ключ",
+    "downloadSshKeyMissing": "Для этой ноды не настроен SSH приватный ключ",
     "maxOnlineUsers": "Лимит онлайн пользователей",
     "maxOnlineHint": "0 = без лимита. При превышении нода скрывается из подписки (если включено).",
     "rankingCoefficient": "Приоритет (ranking)",

--- a/src/routes/panel.js
+++ b/src/routes/panel.js
@@ -65,6 +65,19 @@ function decryptSshPrivateKey(key) {
     return key;
 }
 
+function buildSshKeyFilename(node) {
+    const safe = (value, fallback) => {
+        const normalized = String(value || '')
+            .trim()
+            .replace(/[^a-zA-Z0-9._-]+/g, '-')
+            .replace(/-+/g, '-')
+            .replace(/^-|-$/g, '');
+        return normalized || fallback;
+    };
+
+    return `${safe(node.name, 'node')}-${safe(node.ip, 'unknown')}.key`;
+}
+
 /**
  * Open a direct SSH connection to a node using its stored credentials.
  * @returns {Promise<Client>} connected ssh2 Client
@@ -753,6 +766,37 @@ router.post('/nodes/:id/generate-ssh-key', requireAuth, generateSshKeyLimiter, a
     } catch (error) {
         logger.error(`[Panel] SSH key generation error: ${error.message}`);
         res.status(500).json({ success: false, error: error.message });
+    }
+});
+
+// GET /panel/nodes/:id/download-ssh-key - Download stored SSH private key
+router.get('/nodes/:id/download-ssh-key', requireAuth, async (req, res) => {
+    try {
+        const node = await HyNode.findById(req.params.id).select('name ip ssh.privateKey');
+
+        if (!node) {
+            return res.status(404).type('text/plain; charset=utf-8').send('Node not found');
+        }
+
+        if (!node.ssh?.privateKey) {
+            return res.status(404).type('text/plain; charset=utf-8').send('SSH private key not configured');
+        }
+
+        const privateKey = decryptSshPrivateKey(node.ssh.privateKey);
+        const filename = buildSshKeyFilename(node);
+
+        logger.info(`[Panel] SSH private key downloaded for node ${node.name}`);
+
+        res.set({
+            'Content-Type': 'application/x-pem-file; charset=utf-8',
+            'Content-Disposition': `attachment; filename="${filename}"`,
+            'Cache-Control': 'no-store',
+            'X-Content-Type-Options': 'nosniff',
+        });
+        return res.send(privateKey);
+    } catch (error) {
+        logger.error(`[Panel] SSH key download error: ${error.message}`);
+        return res.status(500).type('text/plain; charset=utf-8').send('Failed to download SSH private key');
     }
 });
 

--- a/views/node-form.ejs
+++ b/views/node-form.ejs
@@ -618,6 +618,17 @@
                 <span class="badge" style="font-size:10px;background:var(--accent);color:#fff;border-radius:10px;padding:1px 6px;margin-left:4px;"><%= node.outbounds.length %></span>
                 <% } %>
             </a>
+            <% if (node.ssh?.privateKey) { %>
+            <a href="/panel/nodes/<%= node._id %>/download-ssh-key" class="action-btn" style="text-decoration:none;text-align:center;">
+                <span class="action-icon"><i class="ti ti-download"></i></span>
+                <span><%= t('nodes.downloadSshKey') %></span>
+            </a>
+            <% } else { %>
+            <span class="action-btn is-disabled" style="text-decoration:none;text-align:center;" title="<%= t('nodes.downloadSshKeyMissing') %>" aria-disabled="true">
+                <span class="action-icon"><i class="ti ti-download"></i></span>
+                <span><%= t('nodes.downloadSshKey') %></span>
+            </span>
+            <% } %>
             <button class="action-btn" onclick="openTerminal()">
                 <span class="action-icon"><i class="ti ti-terminal-2"></i></span>
                 <span><%= t('nodes.terminal') %></span>


### PR DESCRIPTION
## Summary
- Adds ability to download node's SSH private key via UI
- Button appears in the node form alongside other actions
- Disabled (grayed out) if SSH key is not configured for the node
## Changes
- **Frontend**: "Download SSH Key" button in `views/node-form.ejs`
- **Backend**: new route `GET /panel/nodes/:id/download-ssh-key`
- **Localization**: strings `downloadSshKey`, `downloadSshKeyMissing` (en/ru)
- **CSS**: `.action-btn.is-disabled` style for disabled buttons
## Security
- Key is downloadable only if `node.ssh.privateKey` exists
- Headers: `Cache-Control: no-store`, `X-Content-Type-Options: nosniff`
- Filename is sanitized: `node-name-ip.key`
## How to test
1. Create a node with an SSH key (or generate via "Generate SSH Key")
2. Open the node form
3. Click "Download SSH Key"
4. File should download with name `nodename-ip.key`
<img width="1912" height="1242" alt="Без названия" src="https://github.com/user-attachments/assets/72aa7407-6f77-4c73-b306-e1c8c048b4a5" />

