### PR TITLE
feat: make Dokploy Traefik backend port configurable and document Dokploy workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,56 @@ MONGO_PASSWORD=yourmongopassword   # openssl rand -hex 16
 
 ---
 
+## 🐳 Dokploy (Development and Release)
+
+Use `docker-compose.dokploy.yml` when deploying through Dokploy with Traefik.
+
+### Development Mode (build from current branch)
+
+1. In Dokploy, create a project from this repository/branch.
+2. Set compose path to `docker-compose.dokploy.yml`.
+3. Add env vars from `docker.env.example` and set at least:
+   - `MONGO_PASSWORD`
+   - `PANEL_DOMAIN`
+   - `ACME_EMAIL`
+   - `ENCRYPTION_KEY`
+   - `SESSION_SECRET`
+   - `DOKPLOY_PANEL_HOST` (domain used in Traefik `Host(...)` rule)
+   - `DOKPLOY_TRAEFIK_SERVICE_PORT` (Traefik target/backend port, default `3000`)
+4. Deploy: Dokploy will run `build: .` and start the stack.
+
+This mode is best when you test branch changes before publishing a release image.
+
+### Release Mode (Docker Hub image)
+
+If you want stable deploys from Docker Hub tags (without building), replace `backend` image source in Dokploy compose with:
+
+```yaml
+backend:
+  image: clickdevtech/hysteria-panel:latest
+  # or pin a release tag, e.g. clickdevtech/hysteria-panel:v1.2.3
+  restart: always
+  depends_on:
+    mongo:
+      condition: service_healthy
+    redis:
+      condition: service_healthy
+  expose:
+    - "${DOKPLOY_TRAEFIK_SERVICE_PORT:-3000}"
+  labels:
+    - "traefik.enable=true"
+    - "traefik.http.routers.celerity.rule=Host(`${DOKPLOY_PANEL_HOST}`)"
+    - "traefik.http.routers.celerity.entrypoints=websecure"
+    - "traefik.http.routers.celerity.tls=true"
+    - "traefik.http.services.celerity.loadbalancer.server.port=${DOKPLOY_TRAEFIK_SERVICE_PORT:-3000}"
+  env_file:
+    - .env
+```
+
+Use `latest` for fast updates, or pin an explicit tag for predictable production rollouts.
+
+---
+
 ## ✨ Features
 
 - 🖥 **Web Panel** — Full UI for managing nodes and users
@@ -801,6 +851,8 @@ volumes:
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `PANEL_DOMAIN` | ✅ | Panel domain |
+| `DOKPLOY_PANEL_HOST` | ❌ | Traefik host for Dokploy (`Host(...)` rule) |
+| `DOKPLOY_TRAEFIK_SERVICE_PORT` | ❌ | Traefik/backend service port in Dokploy (default: `3000`) |
 | `ACME_EMAIL` | ✅ | Let's Encrypt email |
 | `ENCRYPTION_KEY` | ✅ | SSH encryption key (32 chars) |
 | `SESSION_SECRET` | ✅ | Session secret |

--- a/README.ru.md
+++ b/README.ru.md
@@ -71,6 +71,56 @@ MONGO_PASSWORD=парольмонго         # openssl rand -hex 16
 
 ---
 
+## 🐳 Dokploy (разработка и релиз)
+
+Используйте `docker-compose.dokploy.yml` при деплое через Dokploy с Traefik.
+
+### Режим разработки (сборка из текущей ветки)
+
+1. В Dokploy создайте проект из этого репозитория/ветки.
+2. Укажите путь к compose-файлу: `docker-compose.dokploy.yml`.
+3. Добавьте переменные окружения из `docker.env.example`, минимум:
+   - `MONGO_PASSWORD`
+   - `PANEL_DOMAIN`
+   - `ACME_EMAIL`
+   - `ENCRYPTION_KEY`
+   - `SESSION_SECRET`
+   - `DOKPLOY_PANEL_HOST` (домен для правила Traefik `Host(...)`)
+   - `DOKPLOY_TRAEFIK_SERVICE_PORT` (порт Traefik/backend, по умолчанию `3000`)
+4. Запустите деплой: Dokploy выполнит `build: .` и поднимет стек.
+
+Этот режим удобен для проверки изменений из ветки до публикации релизного образа.
+
+### Режим релиза (образ из Docker Hub)
+
+Если нужен стабильный деплой по тегам Docker Hub (без сборки), замените источник `backend` в compose на образ:
+
+```yaml
+backend:
+  image: clickdevtech/hysteria-panel:latest
+  # или зафиксируйте тег релиза, например clickdevtech/hysteria-panel:v1.2.3
+  restart: always
+  depends_on:
+    mongo:
+      condition: service_healthy
+    redis:
+      condition: service_healthy
+  expose:
+    - "${DOKPLOY_TRAEFIK_SERVICE_PORT:-3000}"
+  labels:
+    - "traefik.enable=true"
+    - "traefik.http.routers.celerity.rule=Host(`${DOKPLOY_PANEL_HOST}`)"
+    - "traefik.http.routers.celerity.entrypoints=websecure"
+    - "traefik.http.routers.celerity.tls=true"
+    - "traefik.http.services.celerity.loadbalancer.server.port=${DOKPLOY_TRAEFIK_SERVICE_PORT:-3000}"
+  env_file:
+    - .env
+```
+
+`latest` подходит для быстрых обновлений, фиксированный тег — для предсказуемых прод-выкаток.
+
+---
+
 ## ✨ Возможности
 
 - 🖥 **Веб-панель** — полноценный UI для управления нодами и пользователями
@@ -853,6 +903,8 @@ volumes:
 | Переменная           | Обязательно | Описание                                      |
 | -------------------- | ----------- | --------------------------------------------- |
 | `PANEL_DOMAIN`       | ✅           | Домен панели                                  |
+| `DOKPLOY_PANEL_HOST` | ❌           | Хост Traefik в Dokploy (правило `Host(...)`) |
+| `DOKPLOY_TRAEFIK_SERVICE_PORT` | ❌   | Порт Traefik/backend сервиса в Dokploy (default: `3000`) |
 | `ACME_EMAIL`         | ✅           | Email для Let's Encrypt                       |
 | `ENCRYPTION_KEY`     | ✅           | Ключ шифрования SSH (32 символа)              |
 | `SESSION_SECRET`     | ✅           | Секрет сессий                                 |

--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -35,19 +35,19 @@ services:
       redis:
         condition: service_healthy
     expose:
-      - "3000"
+      - "${DOKPLOY_TRAEFIK_SERVICE_PORT:-3000}"
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.celerity.rule=Host(`${DOKPLOY_PANEL_HOST}`)"
       - "traefik.http.routers.celerity.entrypoints=websecure"
       - "traefik.http.routers.celerity.tls=true"
-      - "traefik.http.services.celerity.loadbalancer.server.port=3000"
+      - "traefik.http.services.celerity.loadbalancer.server.port=${DOKPLOY_TRAEFIK_SERVICE_PORT:-3000}"
     env_file:
       - .env
     environment:
       MONGO_URI: mongodb://${MONGO_USER:-hysteria}:${MONGO_PASSWORD}@mongo:27017/hysteria?authSource=admin
       REDIS_URL: redis://redis:6379
-      PORT: 3000
+      PORT: ${DOKPLOY_TRAEFIK_SERVICE_PORT:-3000}
       USE_CADDY: "true"
     volumes:
       - app_logs:/app/logs

--- a/docker.env.example
+++ b/docker.env.example
@@ -8,6 +8,8 @@
 PANEL_DOMAIN=panel.example.com
 # Хост для Traefik роутера Dokploy (без https://)
 DOKPLOY_PANEL_HOST=panel.example.com
+# Порт backend сервиса в Dokploy + порт Traefik loadbalancer
+DOKPLOY_TRAEFIK_SERVICE_PORT=3000
 
 # Email для Let's Encrypt сертификата
 ACME_EMAIL=admin@example.com


### PR DESCRIPTION
## Summary
This PR improves Dokploy deployment flexibility and updates documentation for both development and release workflows.
### What changed
- Added configurable Dokploy/Traefik backend port support via:
  - `DOKPLOY_TRAEFIK_SERVICE_PORT` (default: `3000`)
- Updated `docker-compose.dokploy.yml` to use that variable in:
  - `backend.expose`
  - `traefik.http.services.celerity.loadbalancer.server.port`
  - `PORT` environment variable
- Updated `docker.env.example`:
  - Added `DOKPLOY_TRAEFIK_SERVICE_PORT=3000`
  - Kept `DOKPLOY_PANEL_HOST` for Traefik host rule
- Added Dokploy documentation in both readmes:
  - `README.md` (English)
  - `README.ru.md` (Russian)
- New docs now cover:
  - Dokploy development mode (build from current branch)
  - Dokploy release mode (Docker Hub image)
  - Required/recommended Dokploy env variables
  - Host + port parameterization examples
## Why
Dokploy deployments previously had hardcoded backend port assumptions.  
This change makes Traefik routing and backend port mapping configurable per environment without editing compose files each time.
## Verification
- Verified compose now uses `${DOKPLOY_TRAEFIK_SERVICE_PORT:-3000}` consistently for Dokploy service/Traefik target.
- Verified `docker.env.example` includes both:
  - `DOKPLOY_PANEL_HOST`
  - `DOKPLOY_TRAEFIK_SERVICE_PORT`
- Verified both README files include updated Dokploy instructions and env variable references.
## Notes
- No application logic changes.
- This is a deployment/config + documentation improvement.