### PR TITLE
feat(hysteria): add Gecko obfs support (Hysteria 2.9.x)

### DIFF
--- a/src/models/hyNodeModel.js
+++ b/src/models/hyNodeModel.js
@@ -257,7 +257,7 @@ const hyNodeSchema = new mongoose.Schema({
     hopInterval: { type: String, default: '' },
     portConfigs: { type: [portConfigSchema], default: [] },
     obfs: {
-        type: { type: String, enum: ['', 'salamander'], default: '' },
+        type: { type: String, enum: ['', 'salamander', 'gecko'], default: '' },
         password: { type: String, default: '' },
     },
     acme: { type: acmeOptionsSchema, default: () => ({}) },

--- a/src/routes/subscription.js
+++ b/src/routes/subscription.js
@@ -313,8 +313,8 @@ function generateURI(user, node, config) {
         const hopSec = parseDurationSeconds(normalizeHopInterval(config.hopInterval));
         if (hopSec > 0) params.push(`mportHopInt=${hopSec}`);
     }
-    if (config.obfs === 'salamander' && config.obfsPassword) {
-        params.push('obfs=salamander');
+    if (config.obfs && config.obfsPassword) {
+        params.push(`obfs=${config.obfs}`);
         params.push(`obfs-password=${encodeURIComponent(config.obfsPassword)}`);
     }
     
@@ -985,8 +985,8 @@ function generateClashYAML(user, nodes, routing) {
                 if (cfg.portRange) proxy += `\n    ports: ${cfg.portRange}`;
                 const hopIntervalSec = parseDurationSeconds(normalizeHopInterval(cfg.hopInterval));
                 if (hopIntervalSec > 0) proxy += `\n    hop-interval: ${hopIntervalSec}`;
-                if (cfg.obfs === 'salamander' && cfg.obfsPassword) {
-                    proxy += `\n    obfs: salamander\n    obfs-password: "${cfg.obfsPassword}"`;
+                if (cfg.obfs && cfg.obfsPassword) {
+                    proxy += `\n    obfs: ${cfg.obfs}\n    obfs-password: "${cfg.obfsPassword}"`;
                 }
                 proxies.push(proxy);
             });
@@ -1238,8 +1238,8 @@ function _buildV2rayOutboundsForNode(user, node, tagOverride) {
             },
         };
 
-        if (cfg.obfs === 'salamander' && cfg.obfsPassword) {
-            streamSettings.udpmasks = [{ type: 'salamander', settings: { password: cfg.obfsPassword } }];
+        if (cfg.obfs && cfg.obfsPassword) {
+            streamSettings.udpmasks = [{ type: cfg.obfs, settings: { password: cfg.obfsPassword } }];
         }
 
         built.push({
@@ -1514,8 +1514,8 @@ function generateSingboxJSON(user, nodes, routing) {
                     outbound.hop_interval = hopInterval;
                 }
 
-                if (cfg.obfs === 'salamander' && cfg.obfsPassword) {
-                    outbound.obfs = { type: 'salamander', password: cfg.obfsPassword };
+                if (cfg.obfs && cfg.obfsPassword) {
+                    outbound.obfs = { type: cfg.obfs, password: cfg.obfsPassword };
                 }
 
                 proxyOutbounds.push(outbound);

--- a/src/services/configGenerator.js
+++ b/src/services/configGenerator.js
@@ -232,10 +232,10 @@ function generateNodeConfig(node, authUrl, options = {}) {
         }
     }
     
-    if (node.obfs?.password) {
+    if (node.obfs?.type && node.obfs?.password) {
         config.obfs = {
-            type: 'salamander',
-            salamander: { password: node.obfs.password },
+            type: node.obfs.type,
+            [node.obfs.type]: { password: node.obfs.password },
         };
     }
 

--- a/views/partials/node-form/hysteria.ejs
+++ b/views/partials/node-form/hysteria.ejs
@@ -29,9 +29,10 @@
                         <select id="obfsType" name="obfs.type" onchange="toggleObfsPassword()">
                             <option value="" <%= !node?.obfs?.type ? 'selected' : '' %>><%= t('nodes.off') %></option>
                             <option value="salamander" <%= node?.obfs?.type === 'salamander' ? 'selected' : '' %>>Salamander</option>
+                            <option value="gecko" <%= node?.obfs?.type === 'gecko' ? 'selected' : '' %>>Gecko</option>
                         </select>
                     </div>
-                    <div class="form-group" id="obfsPasswordGroup" style="<%= node?.obfs?.type === 'salamander' ? '' : 'display:none' %>">
+                    <div class="form-group" id="obfsPasswordGroup" style="<%= node?.obfs?.type ? '' : 'display:none' %>">
                         <label for="obfsPassword"><%= t('nodes.obfsPassword') %></label>
                         <div class="input-with-button">
                             <input type="text" id="obfsPassword" name="obfs.password"

--- a/views/partials/node-form/scripts.ejs
+++ b/views/partials/node-form/scripts.ejs
@@ -949,7 +949,7 @@ function generateExtraXrayKeys() {
 
 function toggleObfsPassword() {
     const type = document.getElementById('obfsType').value;
-    document.getElementById('obfsPasswordGroup').style.display = type === 'salamander' ? '' : 'none';
+    document.getElementById('obfsPasswordGroup').style.display = type ? '' : 'none';
 }
 
 function toggleCustomConfig() {


### PR DESCRIPTION
## Summary

Adds support for Hysteria's new `gecko` obfuscation type ([apernet/hysteria v2.9.2](https://github.com/apernet/hysteria/releases/tag/app%2Fv2.9.2)). Gecko fragments QUIC handshake packets to evade DPI/fingerprinting.

Without this patch the panel can only emit `obfs=salamander` in client configs, so even if an operator enables gecko on a node's `/etc/hysteria/config.yaml`, clients can't connect through the panel-generated subscriptions.

## Changes

- `src/models/hyNodeModel.js` — add `'gecko'` to the `obfs.type` enum.
- `src/routes/subscription.js` — 4 generators (hysteria2:// URI, Clash YAML, V2Ray udpmasks, sing-box outbound) now pass `cfg.obfs` through instead of the literal `'salamander'`. The original `salamander` behavior is preserved verbatim.
- `src/services/configGenerator.js` — the server-side config emitter writes the obfs type from the node record (`{ type, [type]: { password } }`), so it stays correct for any supported obfs (and now requires `node.obfs.type` to be set, not just the password).
- `views/partials/node-form/hysteria.ejs` + `scripts.ejs` — add `Gecko` to the dropdown; the password field is now shown for any non-empty obfs type instead of being salamander-specific.

## Notes

- Server side: `gecko` is implemented as a layer on top of salamander (same password), so existing salamander passwords work as-is.
- Client side: requires Hysteria CLI 2.9.2 or sing-box v1.14.0-alpha.26+ (sing-box stable does not yet have it).
- Backwards compatible: nodes still on salamander keep working without changes.