### PR TITLE
fix: add English fallback for incomplete locales

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon index.js",
-    "test": "node scripts/test-session-cookie-config.js && node scripts/test-node-ui-meta.js && node scripts/test-node-active-api.js",
+    "test": "node scripts/test-session-cookie-config.js && node scripts/test-i18n-fallback.js && node scripts/test-node-ui-meta.js && node scripts/test-node-active-api.js",
     "build:assets": "npx --yes esbuild public/css/style.css public/css/network.css --minify --loader:.css=css --outdir=public/css --out-extension:.css=.min.css --allow-overwrite && npx --yes esbuild public/js/network.js --minify --outfile=public/js/network.min.js"
   },
   "dependencies": {

--- a/scripts/test-i18n-fallback.js
+++ b/scripts/test-i18n-fallback.js
@@ -1,0 +1,74 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function loadI18nWithLocales(localeMap) {
+    const source = fs.readFileSync(path.join(__dirname, '../src/middleware/i18n.js'), 'utf8');
+    const fakePath = {
+        ...path,
+        join: (...parts) => {
+            const filename = parts[parts.length - 1];
+            if (Object.prototype.hasOwnProperty.call(localeMap, filename)) {
+                return `/locales/${filename}`;
+            }
+            return path.join(...parts);
+        },
+    };
+    const fakeFs = {
+        existsSync: filePath => Object.prototype.hasOwnProperty.call(localeMap, path.basename(filePath)),
+        readFileSync: filePath => localeMap[path.basename(filePath)],
+    };
+    const module = { exports: {} };
+
+    vm.runInNewContext(source, {
+        require: name => {
+            if (name === 'fs') return fakeFs;
+            if (name === 'path') return fakePath;
+            return require(name);
+        },
+        module,
+        exports: module.exports,
+        __dirname: '/app/src/middleware',
+        console,
+    }, { filename: 'i18n.js' });
+
+    return module.exports;
+}
+
+const i18n = loadI18nWithLocales({
+    'en.json': JSON.stringify({
+        dashboard: {
+            title: 'Dashboard',
+        },
+    }),
+    'ru.json': JSON.stringify({
+        dashboard: {},
+    }),
+    'zh-CN.json': JSON.stringify({
+        dashboard: {},
+    }),
+});
+
+assert.strictEqual(
+    i18n.t('dashboard.title', 'ru'),
+    'Dashboard',
+    'Russian locale should fall back to English when a key is missing'
+);
+assert.strictEqual(
+    i18n.getLocale('ru').dashboard.title,
+    'Dashboard',
+    'Merged Russian locale should include English fallback values'
+);
+assert.strictEqual(
+    i18n.t('dashboard.title', 'zh-CN'),
+    'Dashboard',
+    'Chinese locale should fall back to English when a key is missing'
+);
+assert.strictEqual(
+    i18n.getLocale('zh-CN').dashboard.title,
+    'Dashboard',
+    'Merged Chinese locale should include English fallback values'
+);
+
+console.log('i18n fallback tests passed');

--- a/src/middleware/i18n.js
+++ b/src/middleware/i18n.js
@@ -81,14 +81,12 @@ function getFallbackChain(lang = DEFAULT_LANG) {
     const normalized = normalizeLanguage(lang) || DEFAULT_LANG;
     const chain = [normalized];
 
-    if (normalized === DEFAULT_LANG) {
-        return chain;
-    }
-
     if (normalized !== FALLBACK_LANG) {
         chain.push(FALLBACK_LANG);
     }
-    chain.push(DEFAULT_LANG);
+    if (normalized !== DEFAULT_LANG) {
+        chain.push(DEFAULT_LANG);
+    }
 
     return [...new Set(chain)];
 }
@@ -233,4 +231,3 @@ module.exports = {
     SUPPORTED_LANGS,
     DEFAULT_LANG,
 };
-


### PR DESCRIPTION
## Summary

Fix i18n fallback behavior for incomplete locale files.

- Add English fallback for missing keys in the default Russian locale
- Keep existing fallback behavior for `zh-CN`
- Add regression coverage for both `ru` and `zh-CN` fallback paths

## Root Cause

`getFallbackChain()` returned early when the active language was the default language (`ru`). Because of that, missing Russian translation keys never tried the English fallback and could appear in the UI as raw keys like `dashboard.title`.

## Validation

- `npm test`
- `git diff --check`