### PR TITLE
fix(setup): client-side form validation with i18n messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon index.js",
-    "test": "node scripts/test-session-cookie-config.js && node scripts/test-i18n-fallback.js && node scripts/test-node-ui-meta.js && node scripts/test-node-active-api.js && node scripts/test-auth-subscription-boundaries.js",
+    "test": "node scripts/test-session-cookie-config.js && node scripts/test-i18n-fallback.js && node scripts/test-node-ui-meta.js && node scripts/test-node-active-api.js && node scripts/test-auth-subscription-boundaries.js && node scripts/test-setup-ejs-validation.js && node scripts/test-security-ejs-validation.js",
     "build:assets": "npx --yes esbuild public/css/style.css public/css/network.css --minify --loader:.css=css --outdir=public/css --out-extension:.css=.min.css --allow-overwrite && npx --yes esbuild public/js/network.js --minify --outfile=public/js/network.min.js"
   },
   "dependencies": {

--- a/scripts/test-security-ejs-validation.js
+++ b/scripts/test-security-ejs-validation.js
@@ -1,0 +1,93 @@
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const PROJECT_ROOT = path.join(__dirname, '..');
+const SECURITY_EJS_PATH = path.join(PROJECT_ROOT, 'views', 'partials', 'settings', 'security.ejs');
+const LOCALES_DIR = path.join(PROJECT_ROOT, 'src', 'locales');
+
+function readSecurityEjsBody() {
+    return fs.readFileSync(SECURITY_EJS_PATH, 'utf8');
+}
+
+function extractScriptBlock(body) {
+    const matches = body.match(/<script\b[^>]*>([\s\S]*?)<\/script>/gi) || [];
+    return matches.join('\n');
+}
+
+function readLocale(localeName) {
+    const filePath = path.join(LOCALES_DIR, `${localeName}.json`);
+    const raw = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(raw);
+}
+
+function assertLocaleHasPasswordKeys(localeName) {
+    const parsed = readLocale(localeName);
+    assert.ok(parsed.settings, `${localeName}.json must define a "settings" object`);
+    assert.ok(
+        parsed.settings.newPasswordTooShort,
+        `${localeName}.json must define "settings.newPasswordTooShort"`
+    );
+    assert.ok(parsed.setup, `${localeName}.json must define a "setup" object`);
+    assert.ok(
+        parsed.setup.passwordsMismatch,
+        `${localeName}.json must define "setup.passwordsMismatch"`
+    );
+}
+
+const ejsBody = readSecurityEjsBody();
+const scriptBlock = extractScriptBlock(ejsBody);
+
+assert.ok(
+    /<input[\s\S]*?name="newPassword"[\s\S]*?minlength="6"[\s\S]*?>/i.test(ejsBody),
+    'security.ejs must declare a newPassword input with name="newPassword" and minlength="6"'
+);
+
+assert.ok(
+    /<input[\s\S]*?name="confirmPassword"[\s\S]*?minlength="6"[\s\S]*?>/i.test(ejsBody),
+    'security.ejs must declare a confirmPassword input with name="confirmPassword" and minlength="6"'
+);
+
+assert.ok(
+    scriptBlock.length > 0,
+    'security.ejs must contain at least one <script> block'
+);
+
+assert.ok(
+    scriptBlock.includes('setCustomValidity'),
+    'security.ejs <script> block must call setCustomValidity for client-side validation'
+);
+
+assert.ok(
+    scriptBlock.includes('settings.newPasswordTooShort'),
+    'security.ejs <script> block must reference the i18n key "settings.newPasswordTooShort"'
+);
+
+assert.ok(
+    scriptBlock.includes('setup.passwordsMismatch'),
+    'security.ejs <script> block must reference the i18n key "setup.passwordsMismatch"'
+);
+
+assert.ok(
+    scriptBlock.includes('input[name="newPassword"]') ||
+        scriptBlock.includes("input[name='newPassword']"),
+    'security.ejs <script> block must query "input[name=\\"newPassword\\"]"'
+);
+
+assert.ok(
+    scriptBlock.includes('input[name="confirmPassword"]') ||
+        scriptBlock.includes("input[name='confirmPassword']"),
+    'security.ejs <script> block must query "input[name=\\"confirmPassword\\"]"'
+);
+
+assert.ok(
+    /addEventListener\(\s*['"]input['"]/i.test(scriptBlock),
+    'security.ejs <script> block must attach at least one addEventListener("input", ...) listener'
+);
+
+assertLocaleHasPasswordKeys('en');
+assertLocaleHasPasswordKeys('ru');
+assertLocaleHasPasswordKeys('zh-CN');
+
+console.log('security EJS validation tests passed');
+process.exit(0);

--- a/scripts/test-setup-ejs-validation.js
+++ b/scripts/test-setup-ejs-validation.js
@@ -1,0 +1,107 @@
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const PROJECT_ROOT = path.join(__dirname, '..');
+const SETUP_EJS_PATH = path.join(PROJECT_ROOT, 'views', 'setup.ejs');
+const LOCALES_DIR = path.join(PROJECT_ROOT, 'src', 'locales');
+
+function readEjsBody() {
+    return fs.readFileSync(SETUP_EJS_PATH, 'utf8');
+}
+
+function extractScriptBlock(body) {
+    const matches = body.match(/<script\b[^>]*>([\s\S]*?)<\/script>/gi) || [];
+    return matches.join('\n');
+}
+
+function readLocale(localeName) {
+    const filePath = path.join(LOCALES_DIR, `${localeName}.json`);
+    const raw = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(raw);
+}
+
+function assertLocaleHasSetupKeys(localeName) {
+    const parsed = readLocale(localeName);
+    assert.ok(parsed.setup, `${localeName}.json must define a "setup" object`);
+    assert.ok(
+        parsed.setup.usernameTooShort,
+        `${localeName}.json must define "setup.usernameTooShort"`
+    );
+    assert.ok(
+        parsed.setup.passwordTooShort,
+        `${localeName}.json must define "setup.passwordTooShort"`
+    );
+    assert.ok(
+        parsed.setup.passwordsMismatch,
+        `${localeName}.json must define "setup.passwordsMismatch"`
+    );
+}
+
+const ejsBody = readEjsBody();
+const scriptBlock = extractScriptBlock(ejsBody);
+
+assert.ok(
+    /<input[\s\S]*?id="username"[\s\S]*?minlength="3"[\s\S]*?>/i.test(ejsBody),
+    'setup.ejs must declare a username input with id="username" and minlength="3"'
+);
+
+assert.ok(
+    /<input[\s\S]*?id="password"[\s\S]*?minlength="6"[\s\S]*?>/i.test(ejsBody),
+    'setup.ejs must declare a password input with id="password" and minlength="6"'
+);
+
+assert.ok(
+    /<input[\s\S]*?id="passwordConfirm"[\s\S]*?minlength="6"[\s\S]*?>/i.test(ejsBody),
+    'setup.ejs must declare a passwordConfirm input with id="passwordConfirm" and minlength="6"'
+);
+
+assert.ok(
+    scriptBlock.includes('setCustomValidity'),
+    'setup.ejs <script> block must call setCustomValidity for client-side validation'
+);
+
+assert.ok(
+    scriptBlock.includes('setup.usernameTooShort'),
+    'setup.ejs <script> block must reference the i18n key "setup.usernameTooShort"'
+);
+
+assert.ok(
+    scriptBlock.includes('setup.passwordTooShort'),
+    'setup.ejs <script> block must reference the i18n key "setup.passwordTooShort"'
+);
+
+assert.ok(
+    scriptBlock.includes('setup.passwordsMismatch'),
+    'setup.ejs <script> block must reference the i18n key "setup.passwordsMismatch"'
+);
+
+assert.ok(
+    /addEventListener\(\s*['"]input['"]/i.test(scriptBlock),
+    'setup.ejs <script> block must attach at least one addEventListener("input", ...) listener'
+);
+
+assert.ok(
+    scriptBlock.includes("getElementById('username')") ||
+        scriptBlock.includes('getElementById("username")'),
+    'setup.ejs <script> block must look up the #username input via getElementById'
+);
+
+assert.ok(
+    scriptBlock.includes("getElementById('password')") ||
+        scriptBlock.includes('getElementById("password")'),
+    'setup.ejs <script> block must look up the #password input via getElementById'
+);
+
+assert.ok(
+    scriptBlock.includes("getElementById('passwordConfirm')") ||
+        scriptBlock.includes('getElementById("passwordConfirm")'),
+    'setup.ejs <script> block must look up the #passwordConfirm input via getElementById'
+);
+
+assertLocaleHasSetupKeys('en');
+assertLocaleHasSetupKeys('ru');
+assertLocaleHasSetupKeys('zh-CN');
+
+console.log('setup EJS validation tests passed');
+process.exit(0);

--- a/views/partials/settings/security.ejs
+++ b/views/partials/settings/security.ejs
@@ -68,6 +68,40 @@
                             </button>
                         </div>
                     </form>
+
+                    <script>
+                    (function () {
+                        const messages = {
+                            newPasswordTooShort: <%- JSON.stringify(typeof t !== "undefined" ? t("settings.newPasswordTooShort") : "New password must be at least 6 characters") %>,
+                            passwordsMismatch: <%- JSON.stringify(typeof t !== "undefined" ? t("setup.passwordsMismatch") : "Passwords don't match!") %>
+                        };
+
+                        const newPassword = document.querySelector('input[name="newPassword"]');
+                        const confirmPassword = document.querySelector('input[name="confirmPassword"]');
+                        if (!newPassword || !confirmPassword) return;
+
+                        function validateField(input) {
+                            const min = parseInt(input.getAttribute('minlength') || '0', 10);
+                            if (input.value.length > 0 && min > 0 && input.value.length < min) {
+                                input.setCustomValidity(messages.newPasswordTooShort);
+                                return;
+                            }
+                            if (input === confirmPassword && input.value.length > 0 && newPassword.value !== input.value) {
+                                input.setCustomValidity(messages.passwordsMismatch);
+                                return;
+                            }
+                            input.setCustomValidity('');
+                        }
+
+                        [newPassword, confirmPassword].forEach(function (input) {
+                            if (!input) return;
+                            input.addEventListener('input', function () {
+                                validateField(input);
+                                if (input === newPassword) validateField(confirmPassword);
+                            });
+                        });
+                    })();
+                    </script>
                 </div>
             </div>
         </div>

--- a/views/setup.ejs
+++ b/views/setup.ejs
@@ -138,20 +138,40 @@
 
     <script>
     (function () {
+        const usernameInput = document.getElementById('username');
         const passwordInput = document.getElementById('password');
         const confirmInput = document.getElementById('passwordConfirm');
-        const mismatchMessage = <%- JSON.stringify(typeof t !== "undefined" ? t("setup.passwordsMismatch") : "Passwords don't match!") %>;
+        const messages = {
+            usernameTooShort: <%- JSON.stringify(typeof t !== "undefined" ? t("setup.usernameTooShort") : "Administrator username must be at least 3 characters long.") %>,
+            passwordTooShort: <%- JSON.stringify(typeof t !== "undefined" ? t("setup.passwordTooShort") : "Password must be at least 6 characters long.") %>,
+            passwordsMismatch: <%- JSON.stringify(typeof t !== "undefined" ? t("setup.passwordsMismatch") : "Passwords don't match!") %>
+        };
 
-        function validatePasswordMatch() {
-            if (!passwordInput || !confirmInput) return;
-            const mismatch = confirmInput.value && passwordInput.value !== confirmInput.value;
-            confirmInput.setCustomValidity(mismatch ? mismatchMessage : '');
+        function messageForInput(input) {
+            return input === usernameInput ? messages.usernameTooShort : messages.passwordTooShort;
         }
 
-        if (passwordInput && confirmInput) {
-            passwordInput.addEventListener('input', validatePasswordMatch);
-            confirmInput.addEventListener('input', validatePasswordMatch);
+        function validateField(input) {
+            if (!input) return;
+            const minlength = parseInt(input.getAttribute('minlength') || '0', 10);
+            if (input.value.length > 0 && minlength > 0 && input.value.length < minlength) {
+                input.setCustomValidity(messageForInput(input));
+                return;
+            }
+            if (input === confirmInput && input.value.length > 0 && passwordInput.value !== input.value) {
+                input.setCustomValidity(messages.passwordsMismatch);
+                return;
+            }
+            input.setCustomValidity('');
         }
+
+        [usernameInput, passwordInput, confirmInput].forEach(function (input) {
+            if (!input) return;
+            input.addEventListener('input', function () {
+                validateField(input);
+                if (input === passwordInput) validateField(confirmInput);
+            });
+        });
     })();
     </script>
 </body>


### PR DESCRIPTION
Add a <script> block to views/setup.ejs and views/partials/settings/security.ejs that wires setCustomValidity for username, password and confirm-password fields. Each validation message is sourced from the i18n middleware (setup.usernameTooShort, setup.passwordTooShort, settings.newPasswordTooShort, setup.passwordsMismatch) with English fallbacks, matching the existing pattern in views/partials/settings/security.ejs.

<details><summary>image</summary>
<p>

<img width="4140" height="2800" alt="CleanShot 2026-07-01 at 00 00 02@2x" src="https://github.com/user-attachments/assets/34dc7008-bbb1-4c23-be2b-2cf52bae4a99" />
<img width="4140" height="2800" alt="CleanShot 2026-07-01 at 00 00 24@2x" src="https://github.com/user-attachments/assets/75ddcf33-e54b-4429-8c26-db1306011de0" />
<img width="4140" height="2800" alt="CleanShot 2026-06-30 at 23 59 13@2x" src="https://github.com/user-attachments/assets/79811cc5-4f66-44ae-a4d1-b084411987a0" />


</p>
</details> 

Cover the new contract with two standalone Node tests under scripts/:
- test-setup-ejs-validation.js asserts the input attributes (id/minlength), the setCustomValidity hook and the i18n key references in setup.ejs, and that en/ru/zh-CN all expose the expected setup.* keys.
- test-security-ejs-validation.js does the same for the new-password/confirm-password inputs in views/partials/settings/security.ejs.

Wire both scripts into the npm test chain so the new contract is enforced on every run.